### PR TITLE
Implement an alternative version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +417,7 @@ name = "rcan"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "bitfields",
  "blake3",
  "derive_more",
@@ -420,6 +427,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
+ "testresult",
 ]
 
 [[package]]
@@ -530,6 +538,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "testresult"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614b328ff036a4ef882c61570f72918f7e9c5bee1da33f8e7f91e01daee7e56c"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,15 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.95"
+assert_matches = "1.5.0"
 blake3 = "1.5.5"
-derive_more = { version = "1.0.0", features = ["debug"] }
+derive_more = { version = "1.0.0", features = ["debug", "display"] }
 ed25519-dalek = { version = "2.1.1", features = ["serde", "rand_core"] }
 hex = "0.4.3"
 postcard = { version = "1.1.1", features = ["use-std"] }
 rand = "0.8.5"
 serde = { version = "1.0.217", features = ["derive"] }
+testresult = "0.4.1"
 
 [dev-dependencies]
 bitfields = "0.12.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,251 @@
-use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::time::SystemTime;
+use std::ops::Add;
+use std::time::{Duration, SystemTime};
 
 // TODO: better error management
-use anyhow::{ensure, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use ed25519_dalek::ed25519::signature::Signer;
-use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
-use rand::{CryptoRng, Rng};
+use ed25519_dalek::{Signature, SigningKey, VerifyingKey, SIGNATURE_LENGTH};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-// TODO: what's the smalles secure value?
-pub const NONCE_SIZE: usize = 12;
-
 pub const VERSION: u8 = 1;
 
-pub trait Capability:
-    std::fmt::Debug + Sized + Serialize + DeserializeOwned + PartialEq + Eq + Clone
-{
+/// We allow arbitrary capabilities.
+///
+/// An example for a type implementing this trait might be the enum
+/// for some RPC requests.
+///
+/// Capabilities are restricted by "attenuations", which are representations
+/// of predicates on them. `allowed_by_attenuation` is what translates the
+/// predicate representation into an actual predicate.
+///
+/// The `attenutation` must be serializable so it can be used in an rcan,
+/// which is signed.
+pub trait Capability {
+    /// The representation of a restriction on this capability.
+    type Attenuation: Serialize;
+
+    /// Returns some `Err`, when this capability is not allowed with given
+    /// attenuation, otherwise returns `Ok(())`.
+    fn allowed_by_attenuation(&self, attenuation: &Self::Attenuation) -> Result<()>;
 }
 
-impl<T: std::fmt::Debug + Sized + Serialize + DeserializeOwned + PartialEq + Eq + Clone> Capability
-    for T
-{
+/// An authorizer for invocations.
+///
+/// This represents an identity in the form of a public key.
+/// This public key will always be the same as the original issuer of
+/// the capabilities that are invoked against the authorizer.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Authorizer {
+    // Might even make that `SigningKey` and allow it to `sign` rcans?
+    identity: VerifyingKey,
 }
-/// A cap can be delgated, if we can compare it to another one
-/// `cap_a <= cap_b` means that `cap_a` is a subset or equal of `cap_b`
-/// which would allow a delegation.
-pub trait Delegatable: Capability + PartialOrd {
-    fn can_delegate_to_us(&self, other: &Self) -> bool {
-        matches!(
-            self.partial_cmp(other),
-            Some(Ordering::Less) | Some(Ordering::Equal)
+
+impl Authorizer {
+    /// Constructs a new authorizer for given identity.
+    pub fn new(identity: VerifyingKey) -> Self {
+        Self { identity }
+    }
+
+    /// Verifies an invocation of a capability owned by this authorizer,
+    /// that may have been passed through delegations in a proof chain
+    /// and was finally signed back to us from given `invoker`.
+    ///
+    /// Make sure to verify that the `invoker` signed and authenticated the
+    /// message containing the `capability`.
+    pub fn check_invocation_from<C: Capability>(
+        &self,
+        invoker: VerifyingKey,
+        capability: C,
+        proof_chain: &[&Rcan<C::Attenuation>],
+    ) -> Result<()> {
+        let now = SystemTime::now().elapsed()?.as_secs();
+        // We require that proof chains are provided "back-to-front".
+        // So they start with the owner of the capability, then
+        // proceed with the next item in the chain.
+        let mut current_issuer_target = &self.identity;
+        for proof in proof_chain {
+            // Verify proof chain issuer/audience integrity:
+            let issuer = &proof.payload.issuer;
+            let audience = &proof.payload.audience;
+            ensure!(
+                issuer == current_issuer_target,
+                "invocation failed: expected proof to be issued by {}, but was issued by {}",
+                hex::encode(current_issuer_target),
+                hex::encode(issuer),
+            );
+
+            // Verify each proof's time validity:
+            let expiry = &proof.payload.valid_until;
+            ensure!(
+                expiry.is_valid_at(now),
+                "invocation failed: proof expired at {expiry}"
+            );
+
+            // Verify that the capability is actually reached through:
+            let Some(attenuation) = proof
+                .payload
+                .attenuations
+                .get(&VerifyingKeyWrapper(self.identity))
+            else {
+                bail!(
+                    "invocation failed: proof is missing delegation for capability of {}",
+                    hex::encode(self.identity)
+                );
+            };
+
+            // Verify that the capability doesn't break out of attenuations:
+            capability
+                .allowed_by_attenuation(attenuation)
+                .context("invocation failed")?;
+
+            // Continue checking the proof chain's integrity with this
+            // delegation's audience as the next issuer target:
+            current_issuer_target = audience;
+        }
+
+        ensure!(
+        &invoker == current_issuer_target,
+        "invocation failed: expected delegation chain to end in the connection's owner {}, but the connection is authenticated by {} instead",
+        hex::encode(invoker),
+        hex::encode(current_issuer_target),
+    );
+
+        Ok(())
+    }
+}
+
+/// A token for attenuated capability delegations
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Rcan<A> {
+    /// The actual content.
+    pub payload: Payload<A>,
+    /// Signature over the serialized payload.
+    pub signature: Signature,
+}
+
+#[derive(Clone, Serialize, Deserialize, derive_more::Debug, PartialEq, Eq)]
+pub struct Payload<A> {
+    /// The issuer
+    #[debug("{}", hex::encode(issuer))]
+    issuer: VerifyingKey,
+    /// The intended audience
+    #[debug("{}", hex::encode(audience))]
+    audience: VerifyingKey,
+    /// Attenuations on delegated capabilities
+    attenuations: BTreeMap<VerifyingKeyWrapper, A>,
+    /// Valid until unix timestamp in seconds.
+    valid_until: Expires,
+}
+
+/// When an rcan expires
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, derive_more::Display)]
+pub enum Expires {
+    /// Never expires
+    #[display("never")]
+    Never,
+    /// Valid until given unix timestamp in seconds
+    #[display("{_0}")]
+    At(u64),
+}
+
+pub struct RcanBuilder<'s, A> {
+    issuer: &'s SigningKey,
+    audience: VerifyingKey,
+    attenuations: BTreeMap<VerifyingKeyWrapper, A>,
+}
+
+impl<A> Rcan<A> {
+    pub fn builder(issuer: &SigningKey, audience: VerifyingKey) -> RcanBuilder<'_, A> {
+        RcanBuilder {
+            issuer,
+            audience,
+            attenuations: Default::default(),
+        }
+    }
+
+    pub fn encode(&self) -> Vec<u8>
+    where
+        A: Serialize,
+    {
+        postcard::to_extend(&self, vec![VERSION]).expect("vec")
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self>
+    where
+        A: DeserializeOwned,
+    {
+        let Some(version) = bytes.get(0) else {
+            bail!("cannot decode, token is empty");
+        };
+        ensure!(*version == VERSION, "invalid version: {}", version);
+
+        let rcan: Self = postcard::from_bytes(&bytes[1..]).context("decoding")?;
+
+        // Verify the signature
+        let signed = &bytes[..bytes.len() - SIGNATURE_LENGTH]; // make sure to sign the version, too
+        rcan.payload
+            .issuer
+            .verify_strict(&signed, &rcan.signature)?;
+
+        Ok(rcan)
+    }
+}
+
+impl<A> RcanBuilder<'_, A> {
+    pub fn issuing(mut self, attenuation: A) -> Self {
+        self.attenuations.insert(
+            VerifyingKeyWrapper(self.issuer.verifying_key()),
+            attenuation,
+        );
+        self
+    }
+
+    pub fn delegating(mut self, owner: VerifyingKey, attenuation: A) -> Self {
+        self.attenuations
+            .insert(VerifyingKeyWrapper(owner), attenuation);
+        self
+    }
+
+    pub fn sign(self, valid_until: Expires) -> Rcan<A>
+    where
+        A: Serialize,
+    {
+        let payload = Payload {
+            issuer: self.issuer.verifying_key(),
+            audience: self.audience,
+            attenuations: self.attenuations,
+            valid_until,
+        };
+
+        let to_sign = postcard::to_extend(&payload, vec![VERSION]).expect("vec");
+        let signature = self.issuer.sign(&to_sign);
+
+        Rcan { signature, payload }
+    }
+}
+
+impl Expires {
+    pub fn valid_for(duration: Duration) -> Self {
+        Self::At(
+            SystemTime::now()
+                .elapsed()
+                .expect("now is after UNIX_EPOCH")
+                .add(duration)
+                .as_secs(),
         )
     }
-}
 
-impl<C: Capability + PartialOrd> Delegatable for C {}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct Caps<C: Capability = ()>(
-    #[serde(bound = "C: Capability")] BTreeMap<VerifyingKeyWrapper, C>,
-);
-
-impl<C: Capability> Default for Caps<C> {
-    fn default() -> Self {
-        Self(BTreeMap::new())
+    pub fn is_valid_at(&self, time: u64) -> bool {
+        match self {
+            Expires::Never => true,
+            Expires::At(expiry) => *expiry >= time,
+        }
     }
 }
+
+// Private stuff
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default, derive_more::Debug)]
 #[repr(transparent)]
@@ -67,510 +264,117 @@ impl Ord for VerifyingKeyWrapper {
     }
 }
 
-impl<C: Capability> Caps<C> {
-    pub fn insert(&mut self, key: VerifyingKey, cap: C) {
-        self.0.insert(VerifyingKeyWrapper(key), cap);
-    }
-
-    pub fn get(&self, key: &VerifyingKey) -> Option<&C> {
-        self.0.get(&VerifyingKeyWrapper(*key))
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&VerifyingKey, &C)> {
-        self.0.iter().map(|(k, c)| (&k.0, c))
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, derive_more::Debug, PartialEq, Eq)]
-pub struct Payload<C: Capability> {
-    /// The issuer
-    #[debug("{}", hex::encode(issuer))]
-    issuer: VerifyingKey,
-    /// The intended audience
-    #[debug("{}", hex::encode(audience))]
-    audience: VerifyingKey,
-    /// Nonce, to avoid replayability.
-    #[debug("{}", hex::encode(nonce))]
-    nonce: [u8; NONCE_SIZE],
-    /// Capabilities
-    #[serde(bound = "C: Capability")]
-    caps: Caps<C>,
-    /// Valid until unix timestamp in seconds.
-    valid_until: Option<u64>,
-}
-
-impl<C: Capability> Payload<C> {
-    pub fn new<R: Rng + CryptoRng>(
-        mut rng: R,
-        issuer: VerifyingKey,
-        audience: VerifyingKey,
-        caps: Caps<C>,
-    ) -> Self {
-        let nonce: [u8; NONCE_SIZE] = rng.gen();
-
-        Self {
-            issuer,
-            audience,
-            nonce,
-            caps,
-            valid_until: None,
-        }
-    }
-
-    pub fn set_valid_until(&mut self, valid_until: u64) {
-        self.valid_until.replace(valid_until);
-    }
-
-    pub fn encode_to_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(self).expect("vec")
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct Rcan<C: Capability> {
-    /// The version number.
-    version: u8,
-    /// Signature over the serialized payload.
-    signature: Signature,
-    /// The actaul content.
-    #[serde(bound = "C: Capability")]
-    payload: Payload<C>,
-}
-
-/// offset into a serialized version to the payload
-const PAYLOAD_OFFSET: usize = 1 + Signature::BYTE_SIZE;
-
-impl<C: Capability> Rcan<C> {
-    pub fn new<R: Rng + CryptoRng>(
-        mut rng: R,
-        issuer: &SigningKey,
-        audience: VerifyingKey,
-        caps: Caps<C>,
-    ) -> Self {
-        let payload = Payload::new(&mut rng, issuer.verifying_key(), audience, caps);
-        let payload_ser = payload.encode_to_bytes();
-
-        let signature = issuer.sign(&payload_ser);
-
-        Self {
-            version: VERSION,
-            signature,
-            payload,
-        }
-    }
-
-    pub fn new_with_expiry<R: Rng + CryptoRng>(
-        mut rng: R,
-        issuer: &SigningKey,
-        audience: VerifyingKey,
-        caps: Caps<C>,
-        valid_until: u64,
-    ) -> Self {
-        let mut payload = Payload::new(&mut rng, issuer.verifying_key(), audience, caps);
-        payload.set_valid_until(valid_until);
-
-        let payload_ser = payload.encode_to_bytes();
-        let signature = issuer.sign(&payload_ser);
-
-        Self {
-            version: VERSION,
-            signature,
-            payload,
-        }
-    }
-
-    pub fn from_payload(issuer: &SigningKey, payload: Payload<C>) -> Result<Self> {
-        ensure!(issuer.verifying_key() == payload.issuer, "issuer missmatch");
-        let payload_ser = payload.encode_to_bytes();
-        let signature = issuer.sign(&payload_ser);
-
-        Ok(Self {
-            version: VERSION,
-            signature,
-            payload,
-        })
-    }
-
-    pub fn encode_to_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(self).expect("vec")
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self> {
-        Self::decode_with_time(bytes, now())
-    }
-
-    pub fn decode_with_time(bytes: &[u8], now: u64) -> Result<Self> {
-        let rcan: Rcan<C> = postcard::from_bytes(bytes).context("encoding")?;
-        ensure!(rcan.version == VERSION, "invalid version: {}", rcan.version);
-        rcan.payload
-            .issuer
-            .verify_strict(&bytes[PAYLOAD_OFFSET..], &rcan.signature)?;
-
-        if let Some(valid_until) = rcan.payload.valid_until {
-            ensure!(now <= valid_until, "expired");
-        }
-
-        // verify caps
-        for (cap_root, cap) in rcan.payload.caps.iter() {
-            if cap_root == &rcan.payload.issuer {
-                // simple case, issuer can issuer any cap
-            } else {
-                anyhow::bail!(
-                    "invalid delegation: {} -> {:?}",
-                    hex::encode(cap_root.as_bytes()),
-                    cap
-                );
-            }
-        }
-        Ok(rcan)
-    }
-}
-
-impl<C: Delegatable> Rcan<C> {
-    pub fn delegate<R: Rng + CryptoRng>(
-        &self,
-        mut rng: R,
-        issuer: &SigningKey,
-        audience: VerifyingKey,
-        cap_root: VerifyingKey,
-        cap: C,
-    ) -> Result<Self> {
-        let Some(source_cap) = self.payload.caps.get(&cap_root) else {
-            anyhow::bail!("cap is not available");
-        };
-        if !cap.can_delegate_to_us(source_cap) {
-            anyhow::bail!("cannot delegate: not allowed");
-        }
-
-        let mut caps = Caps::<C>::default();
-        caps.insert(cap_root, cap);
-
-        let nonce: [u8; NONCE_SIZE] = rng.gen();
-        let payload = Payload {
-            issuer: issuer.verifying_key(),
-            nonce,
-            audience,
-            caps,
-            valid_until: None,
-        };
-
-        Self::from_payload(issuer, payload)
-    }
-
-    pub fn decode_with_time_and_chain(
-        bytes: &[u8],
-        now: u64,
-        delegation_chain: &[&Rcan<C>],
-    ) -> Result<Self> {
-        let rcan: Rcan<C> = postcard::from_bytes(bytes).context("encoding")?;
-        ensure!(rcan.version == VERSION, "invalid version: {}", rcan.version);
-        rcan.payload
-            .issuer
-            .verify_strict(&bytes[PAYLOAD_OFFSET..], &rcan.signature)?;
-
-        if let Some(valid_until) = rcan.payload.valid_until {
-            ensure!(now <= valid_until, "expired");
-        }
-
-        // verify caps
-        for (cap_root, cap) in rcan.payload.caps.iter() {
-            if cap_root == &rcan.payload.issuer {
-                // simple case, issuer can issue any cap
-            } else {
-                let mut last_parent = &rcan;
-                let mut smallest_cap = cap;
-
-                loop {
-                    if let Some((parent, parent_cap)) =
-                        find_parent(last_parent, cap_root, delegation_chain)
-                    {
-                        if &parent.payload.issuer == cap_root {
-                            // we have hit the end of the chain, done
-                            break;
-                        } else {
-                            last_parent = parent;
-                            if smallest_cap > parent_cap {
-                                smallest_cap = parent_cap;
-                            };
-                        }
-                    } else {
-                        anyhow::bail!(
-                            "missing delegation chain elements for {:?}: {:?}",
-                            hex::encode(cap_root.as_bytes()),
-                            cap
-                        );
-                    }
-                }
-
-                // make sure the smallest cap is enough to satisfy our cap
-                ensure!(cap.can_delegate_to_us(smallest_cap), "no valid cap found");
-            }
-        }
-
-        Ok(rcan)
-    }
-}
-
-fn find_parent<'a, C: Delegatable>(
-    rcan: &Rcan<C>,
-    cap_root: &VerifyingKey,
-    delegation_chain: &[&'a Rcan<C>],
-) -> Option<(&'a Rcan<C>, &'a C)> {
-    delegation_chain
-        .iter()
-        .filter_map(|other| {
-            if other.payload.audience == rcan.payload.issuer {
-                other.payload.caps.get(cap_root).map(|c| (*other, c))
-            } else {
-                None
-            }
-        })
-        .next()
-}
-
-/// Returns the unix epoch seconds for the current time.
-pub fn now() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
-}
-
 #[cfg(test)]
-mod tests {
-    use bitfields::bitfield;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
+mod test {
+    use assert_matches::assert_matches;
+    use testresult::TestResult;
 
     use super::*;
 
-    #[test]
-    fn test_basics() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-
-        let issuer = SigningKey::generate(&mut rng);
-        let receiver = SigningKey::generate(&mut rng);
-
-        let caps = Caps::<()>::default();
-        let rcan = Rcan::new(&mut rng, &issuer, receiver.verifying_key(), caps);
-
-        let encoded = rcan.encode_to_bytes();
-        let decoded = Rcan::decode(&encoded).expect("failed to verify");
-        assert_eq!(rcan, decoded);
+    enum Rpc {
+        Read { key: &'static str },
+        Write { key: &'static str, value: u64 },
     }
 
-    // Two capabilities:
-    // api: none, read, write
-    // app: none, read, write
-
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
-    #[repr(u8)]
-    enum CapState {
-        None = 0,
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    enum RpcAtt {
         Read = 1,
-        Write = 2,
+        ReadWrite = 2,
+        /// Read, ReadWrite, and any "future ones" that we might not have thought of yet.
+        All = 0,
     }
 
-    impl CapState {
-        const fn from_bits(bits: u8) -> Self {
-            match bits {
-                0 => Self::None,
-                1 => Self::Read,
-                2 => Self::Write,
-                _ => Self::Write, // safe default for higher values
-            }
-        }
+    impl Capability for Rpc {
+        type Attenuation = RpcAtt;
 
-        const fn into_bits(self) -> u8 {
-            self as u8
-        }
-    }
-
-    // Caps get encoded into a bit vector
-    // 3 states per cap, so we need 2 bits per cap
-    #[bitfield(u8)]
-    #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-    struct MyCap {
-        #[bits(2)]
-        api: CapState,
-        #[bits(2)]
-        app: CapState,
-        /// Unused for now
-        #[bits(4)]
-        _padding: u8,
-    }
-
-    impl PartialOrd for MyCap {
-        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-            use std::cmp::Ordering::*;
-
-            let this_api = self.api();
-            let this_app = self.app();
-
-            let other_api = other.api();
-            let other_app = other.app();
-
-            match (this_api.cmp(&other_api), this_app.cmp(&other_app)) {
-                (Less, Less) => Some(Less),
-                (Less, Equal) => Some(Less),
-                (Less, Greater) => None,
-                (Greater, Greater) => Some(Greater),
-                (Greater, Less) => None,
-                (Greater, Equal) => Some(Greater),
-                (Equal, Equal) => Some(Equal),
-                (Equal, Less) => Some(Less),
-                (Equal, Greater) => Some(Greater),
+        fn allowed_by_attenuation(&self, attenuation: &Self::Attenuation) -> Result<()> {
+            match (attenuation, self) {
+                (RpcAtt::Read, Rpc::Read { .. }) => Ok(()),
+                (RpcAtt::Read, _) => Err(anyhow::anyhow!("Illegal invocation")),
+                (RpcAtt::ReadWrite, _) => Ok(()), // all operations are allowed by read-write in the current system
+                (RpcAtt::All, _) => Ok(()),       // all RPC operations are allowed by definition
             }
         }
     }
 
     #[test]
-    fn test_delegate() {
-        let a = MyCapBuilder::new().with_api(CapState::Read).build();
-        let b = MyCapBuilder::new().with_api(CapState::Write).build();
-
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
-        assert_eq!(a.partial_cmp(&a), Some(Ordering::Equal));
-        assert_eq!(b.partial_cmp(&a), Some(Ordering::Greater));
-
-        let a = MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .with_app(CapState::Write)
-            .build();
-        let b = MyCapBuilder::new()
-            .with_api(CapState::Write)
-            .with_app(CapState::Write)
-            .build();
-
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
-        assert!(a.can_delegate_to_us(&b));
-
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-
-        // Delegate from root_issuer -> receiver_1 -> receiver_2
-
-        let root_issuer = SigningKey::generate(&mut rng);
-        let receiver_1 = SigningKey::generate(&mut rng);
-        let receiver_2 = SigningKey::generate(&mut rng);
-
-        let mut caps = Caps::<MyCap>::default();
-
-        // The root_issuer delegates these caps to receiver_1
-        let write_app_read_api_cap = MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .with_app(CapState::Write)
-            .build();
-        caps.insert(root_issuer.verifying_key(), write_app_read_api_cap);
-
-        let rcan_1 = Rcan::new(&mut rng, &root_issuer, receiver_1.verifying_key(), caps);
-        {
-            let encoded = rcan_1.encode_to_bytes();
-            let decoded = Rcan::decode(&encoded).expect("failed to verify");
-            assert_eq!(rcan_1, decoded);
-        }
-
-        // receiver_1 delegates this to receiver_2
-        let read_app_read_api_cap = MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .with_app(CapState::Read)
-            .build();
-
-        let rcan_2 = rcan_1
-            .delegate(
-                &mut rng,
-                &receiver_1,
-                receiver_2.verifying_key(),
-                root_issuer.verifying_key(),
-                read_app_read_api_cap,
-            )
-            .expect("failed to delegate");
-        {
-            let encoded = rcan_2.encode_to_bytes();
-            let err = Rcan::<MyCap>::decode(&encoded).unwrap_err();
-            assert!(err.to_string().contains("invalid delegation"));
-
-            let decoded = Rcan::decode_with_time_and_chain(&encoded, now(), &[&rcan_1])
-                .expect("invalid delegation");
-            assert_eq!(decoded, rcan_2);
-        }
-    }
-
-    #[test]
-    fn test_simple_caps() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-
-        let issuer = SigningKey::generate(&mut rng);
-        let receiver = SigningKey::generate(&mut rng);
-
-        let mut caps = Caps::<MyCap>::default();
-
-        // The issuer delegates these caps
-        let write_app_read_api_cap = MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .with_app(CapState::Write)
-            .build();
-        caps.insert(issuer.verifying_key(), write_app_read_api_cap);
-
-        let rcan = Rcan::new(&mut rng, &issuer, receiver.verifying_key(), caps);
-
-        let encoded = rcan.encode_to_bytes();
-        let decoded = Rcan::decode(&encoded).expect("failed to verify");
-
-        assert_eq!(rcan, decoded);
-
-        assert!(MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .build()
-            .can_delegate_to_us(&MyCapBuilder::new().with_api(CapState::Read).build()));
-
-        assert!(MyCapBuilder::new()
-            .with_api(CapState::Read)
-            .build()
-            .can_delegate_to_us(&MyCapBuilder::new().with_api(CapState::Write).build()));
-    }
-
-    #[test]
-    fn test_expired() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-
-        let issuer = SigningKey::generate(&mut rng);
-        let receiver = SigningKey::generate(&mut rng);
-
-        let caps = Caps::<()>::default();
-        let now = now();
-
-        let rcan =
-            Rcan::new_with_expiry(&mut rng, &issuer, receiver.verifying_key(), caps, now + 1);
-
-        let encoded = rcan.encode_to_bytes();
-
-        // valid
-        let _ = Rcan::<()>::decode_with_time(&encoded, now).expect("should verify");
-
-        // expired
-        let err = Rcan::<()>::decode_with_time(&encoded, now + 3).unwrap_err();
-        assert!(err.to_string().contains("expired"), "{}", err);
-    }
-
-    #[test]
-    fn test_payload_roundtrip() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-
-        let issuer = SigningKey::generate(&mut rng);
-        let receiver = SigningKey::generate(&mut rng);
-
-        let caps = Caps::<()>::default();
-        let mut payload = Payload::new(
-            &mut rng,
-            issuer.verifying_key(),
-            receiver.verifying_key(),
-            caps,
+    fn test_simple_attenuations() {
+        assert_matches!(
+            Rpc::Read { key: "hello" }.allowed_by_attenuation(&RpcAtt::Read),
+            Ok(_)
         );
 
-        payload.set_valid_until(now());
+        assert_matches!(
+            Rpc::Write {
+                key: "hello",
+                value: 42
+            }
+            .allowed_by_attenuation(&RpcAtt::Read),
+            Err(_)
+        );
 
-        let encoded = payload.encode_to_bytes();
-        let decoded = postcard::from_bytes(&encoded).unwrap();
-        assert_eq!(payload, decoded);
+        assert_matches!(
+            Rpc::Write {
+                key: "hello",
+                value: 42
+            }
+            .allowed_by_attenuation(&RpcAtt::ReadWrite),
+            Ok(_)
+        );
+    }
+
+    #[test]
+    fn test_rcan_encoding() -> TestResult {
+        let issuer = SigningKey::from_bytes(&[0u8; 32]);
+        let audience = SigningKey::from_bytes(&[1u8; 32]);
+        let rcan = Rcan::builder(&issuer, audience.verifying_key())
+            .issuing(RpcAtt::ReadWrite)
+            .sign(Expires::Never);
+
+        println!("{}", hex::encode(rcan.encode()));
+        assert_eq!(hex::encode(rcan.encode()), "01203b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29208a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c01203b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da290100cede73ce610c4196671a60335beca23464f06cbc9402bf1c9b7377e36453c43d2652fd2c857fab4300fa92da6ea357435c341123ef89d189884e56f58ce88206");
+        assert_eq!(Rcan::decode(&rcan.encode())?, rcan);
+        Ok(())
+    }
+
+    #[test]
+    fn test_rcan_invocation() -> TestResult {
+        let service = SigningKey::from_bytes(&[0u8; 32]);
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let bob = SigningKey::from_bytes(&[2u8; 32]);
+
+        // The service gives alice access to everything for 60 seconds
+        let service_rcan = Rcan::builder(&service, alice.verifying_key())
+            .issuing(RpcAtt::All)
+            .sign(Expires::valid_for(Duration::from_secs(60)));
+        // alice gives attenuated (only read access) to bob, but doesn't care for how long still
+        let friend_rcan = Rcan::builder(&alice, bob.verifying_key())
+            .delegating(service.verifying_key(), RpcAtt::Read)
+            .sign(Expires::Never);
+        // bob can now pass the authorization test for the service
+        let service_auth = Authorizer::new(service.verifying_key());
+        assert_matches!(
+            service_auth.check_invocation_from(
+                bob.verifying_key(),
+                Rpc::Read { key: "secrets" },
+                &[&service_rcan, &friend_rcan],
+            ),
+            Ok(_)
+        );
+
+        // but bob doesn't have read-write access
+        assert_matches!(
+            service_auth.check_invocation_from(
+                bob.verifying_key(),
+                Rpc::Write {
+                    key: "secret",
+                    value: 1337
+                },
+                &[&service_rcan, &friend_rcan]
+            ),
+            Err(_)
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This implements how I'd imagine a good API for a simple version of UCANs should look like.
Some notable changes:
- Without revocations, there's no need for a nonce in delegations.
- There's no inherent need to verify delegations religiously. It's *useful* to know if a delegation is "valid" (in the sense of there exist some useful set of allowed invocations for given delegation chain), e.g. to show the user whether whatever token they received from a friend actually *does something*, but that needs other APIs.
- We sign over the version, while still keeping the version outside the payload.
- I added some nice utilities like an `RcanBuilder` and an `Expires` enum.

I don't recommend looking at the diff.
Instead:
- Check out the code
- Start by looking at and running the tests
- Then look at the definitions from top to bottom, there exist useful doc comments.