### PR TITLE
fix: properly calculate expiry times

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,4 +399,17 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_expiry() {
+        let issuer = SigningKey::from_bytes(&[0u8; 32]);
+        let audience = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let rcan = Rcan::issuing_builder(&issuer, audience, Rpc::All)
+            .sign(Expires::valid_for(Duration::from_secs(60)));
+        assert!(rcan.expires().is_valid_at(UNIX_EPOCH));
+        let now = SystemTime::now();
+        assert!(rcan.expires().is_valid_at(now));
+        let future = now + Duration::from_secs(61);
+        assert!(!rcan.expires().is_valid_at(future));
+    }
 }


### PR DESCRIPTION
I think the time calculations where wrong. [`SystemTime::elapsed()`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.elapsed) is not the time since the unix epoch but the difference to the current wall clock. What we want to do instead is calculate difference to the UNIX_EPOCH.

Also added a test.